### PR TITLE
fix Brazilian Portuguese keyboard missing AltGr keys

### DIFF
--- a/src/codepages.cpp
+++ b/src/codepages.cpp
@@ -140,12 +140,15 @@ const VirtualKeyToASCII VK2ASCII1252[] = {
   { VK_SECTION,      0xa7 },    // §
   { VK_CURRENCY,     0xa4 },    // ¤
   { VK_HALF,         0xbd },    // ½
+  { VK_UPPER_1,      0xb9 },    // ¹
   { VK_MASCULIN_ORD, 0xba },    // º
   { VK_FEMININ_ORD,  0xaa },    // ª
+  { VK_CENT,         0xa2 },    // ¢
   { VK_LEFTGUILLEMET,0xab },    // «
   { VK_RIGHTGUILLEMET,0xbb },   // »
   { VK_NEGATION,     0xac },    // ¬
   { VK_SQUARE,       0xb2 },    // ²
+  { VK_CUBE,         0xb3 },    // ³
   { VK_MU,           0xb5 },    // µ
   { VK_CEDILLA_C,    0xc7 },    // Ç
   { VK_TILDE_n,      0xf1 },    // ñ

--- a/src/devdrivers/kbdlayouts.cpp
+++ b/src/devdrivers/kbdlayouts.cpp
@@ -2188,7 +2188,8 @@ const KeyboardLayout BrazilianPortugueseLayout {
     { 0x4A, VK_SEMICOLON },
     { 0x5B, VK_LEFTBRACKET },
     { 0x5D, VK_RIGHTBRACKET },
-    // { 0x00, VK_KP_PERIOD },
+    { 0x71, VK_KP_PERIOD },
+    { 0x87, VK_SLASH },
   },
 
   // extended scancodes (0xE0..)
@@ -2199,11 +2200,23 @@ const KeyboardLayout BrazilianPortugueseLayout {
   //  in_key, { CTRL, LALT, RALT, SHIFT }, out_key
   {
     { VK_QUOTE,       { 0, 0, 0, 1 }, VK_QUOTEDBL },     // SHIFT "'" = """
-    { VK_ACUTEACCENT, { 0, 0, 0, 1 }, VK_GRAVEACCENT },  // SHIFT "`" = "'"
+    { VK_6,           { 0, 0, 0, 1 }, VK_DIAERESIS },    // SHIFT "6" = "¨"
+    { VK_ACUTEACCENT, { 0, 0, 0, 1 }, VK_GRAVEACCENT },  // SHIFT "´" = "`"
     { VK_TILDE,       { 0, 0, 0, 1 }, VK_CARET },        // SHIFT "~" = "^"
     { VK_CEDILLA_c,   { 0, 0, 0, 1 }, VK_CEDILLA_C },    // SHIFT "ç" = "Ç"
     { VK_LEFTBRACKET, { 0, 0, 0, 1 }, VK_LEFTBRACE },    // SHIFT "[" = "{"
     { VK_RIGHTBRACKET,{ 0, 0, 0, 1 }, VK_RIGHTBRACE },   // SHIFT "]" = "}"
+    { VK_1,           { 0, 0, 1, 0 }, VK_UPPER_1 },      // ALTGR "1" = "¹"
+    { VK_2,           { 0, 0, 1, 0 }, VK_SQUARE },       // ALTGR "2" = "²"
+    { VK_3,           { 0, 0, 1, 0 }, VK_CUBE },         // ALTGR "3" = "³"
+    { VK_4,           { 0, 0, 1, 0 }, VK_POUND },        // ALTGR "4" = "£"
+    { VK_5,           { 0, 0, 1, 0 }, VK_CENT },         // ALTGR "5" = "¢"
+    { VK_6,           { 0, 0, 1, 0 }, VK_NEGATION },     // ALTGR "6" = "¬"
+    { VK_EQUALS,      { 0, 0, 1, 0 }, VK_SECTION },      // ALTGR "=" = "§"
+    { VK_e,           { 0, 0, 1, 0 }, VK_EURO },         // ALTGR "e" = "€"
+    { VK_RIGHTBRACKET,{ 0, 0, 1, 0 }, VK_MASCULIN_ORD }, // ALTGR "]" = "º"
+    { VK_LEFTBRACKET, { 0, 0, 1, 0 }, VK_FEMININ_ORD },  // ALTGR "[" = "ª"
+    { VK_SLASH,       { 0, 0, 1, 0 }, VK_DEGREE },       // ALTGR "/" = "°"
   },
 
   // deadkeys

--- a/src/fabutils.h
+++ b/src/fabutils.h
@@ -1368,6 +1368,11 @@ enum VirtualKey {
   VK_DEAD_CARET,      /** Caret when we need seperate code for dead key*/
   VK_DEAD_TILDE,      /** Tilde when we need seperate code for dead key*/
 
+  // Missing code page 1252 virtual keys
+  VK_UPPER_1,         /** Superscript 1   : ¹ */
+  VK_CUBE,            /** Superscript 3   : ³ */
+  VK_CENT,            /** Cent (currency) : ¢ */
+ 
   // Japanese layout support
   VK_YEN,
   VK_MUHENKAN,


### PR DESCRIPTION
Added missing code page 1252 virtual keys and respective AltGr mappings