### PR TITLE
Fixed crash bug in Sprite method nextFrame

### DIFF
--- a/src/displaycontroller.h
+++ b/src/displaycontroller.h
@@ -568,7 +568,7 @@ struct Sprite {
   ~Sprite();
   Bitmap * getFrame() { return frames ? frames[currentFrame] : nullptr; }
   int getFrameIndex() { return currentFrame; }
-  void nextFrame() { ++currentFrame; if (currentFrame >= framesCount) currentFrame = 0; }
+  void nextFrame() { currentFrame = (currentFrame  < framesCount - 1) ? currentFrame + 1 : 0; }
   Sprite * setFrame(int frame) { currentFrame = frame; return this; }
   Sprite * addBitmap(Bitmap * bitmap);
   Sprite * addBitmap(Bitmap * bitmap[], int count);


### PR DESCRIPTION
The details are in the linked card - I've had this code running now for 90 minutes without falling over, previous it would run for no more than 10 minutes before crashing.
To test, run sprites_4.bas in BBC BASIC (the current 16-bit version) using versions 1.04 of Agon MOS and VDP.