### PR TITLE
add canvas::copyToBitmap

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -510,6 +510,16 @@ void Canvas::drawBitmap(int X, int Y, Bitmap const * bitmap)
 }
 
 
+void Canvas::copyToBitmap(int srcX, int srcY, Bitmap const * bitmap)
+{
+  if (bitmap->format != PixelFormat::Native) return;
+  Primitive p;
+  p.cmd               = PrimitiveCmd::CopyToBitmap;
+  p.bitmapDrawingInfo = BitmapDrawingInfo(srcX, srcY, bitmap);
+  m_displayController->addPrimitive(p);
+}
+
+
 void Canvas::swapBuffers()
 {
   Primitive p;

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -717,6 +717,18 @@ public:
   void drawBitmap(int X, int Y, Bitmap const * bitmap);
 
   /**
+   * @brief Copies an area of screen to a bitmap from specified position.
+   *
+   * The bitmap provided must be a "native" format bitmap (one byte per pixel).
+   * Width and height information are taken from the bitmap structure.
+   *
+   * @param X Horizontal position of source area.
+   * @param Y Vertical position of source area.
+   * @param bitmap Pointer to bitmap structure.
+   */
+  void copyToBitmap(int X, int Y, Bitmap const * bitmap);
+
+  /**
    * @brief Draws a sequence of lines.
    *
    * @param points A pointer to an array of Point objects. Points array is copied to a temporary buffer.

--- a/src/dispdrivers/vga16controller.cpp
+++ b/src/dispdrivers/vga16controller.cpp
@@ -448,6 +448,15 @@ void VGA16Controller::rawDrawBitmap_RGBA8888(int destX, int destY, Bitmap const 
 }
 
 
+void VGA16Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount)
+{
+  genericRawCopyToBitmap(srcX, srcY, width, (uint8_t*)saveBuffer, X1, Y1, XCount, YCount,
+                       [&] (int y)                { return (uint8_t*) m_viewPort[y]; },     // rawGetRow
+                       [&] (uint8_t * row, int x) { return VGA16_GETPIXELINROW(row, x); }   // rawGetPixelInRow
+                      );
+}
+
+
 void IRAM_ATTR VGA16Controller::ISRHandler(void * arg)
 {
   #if FABGLIB_VGAXCONTROLLER_PERFORMANCE_CHECK

--- a/src/dispdrivers/vga16controller.h
+++ b/src/dispdrivers/vga16controller.h
@@ -161,6 +161,9 @@ private:
   void rawDrawBitmap_RGBA8888(int destX, int destY, Bitmap const * bitmap, void * saveBackground, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
+  void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
+
+  // abstract method of BitmappedDisplayController
   void rawFillRow(int y, int x1, int x2, RGB888 color);
   void rawFillRow(int y, int x1, int x2, uint8_t colorIndex);
 

--- a/src/dispdrivers/vga2controller.cpp
+++ b/src/dispdrivers/vga2controller.cpp
@@ -451,6 +451,15 @@ void VGA2Controller::rawDrawBitmap_RGBA8888(int destX, int destY, Bitmap const *
 }
 
 
+void VGA2Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount)
+{
+  genericRawCopyToBitmap(srcX, srcY, width, (uint8_t*)saveBuffer, X1, Y1, XCount, YCount,
+                       [&] (int y)                { return (uint8_t*) m_viewPort[y]; },   // rawGetRow
+                       [&] (uint8_t * row, int x) { return VGA2_GETPIXELINROW(row, x); }  // rawGetPixelInRow
+                      );
+}
+
+
 void IRAM_ATTR VGA2Controller::ISRHandler(void * arg)
 {
   #if FABGLIB_VGAXCONTROLLER_PERFORMANCE_CHECK

--- a/src/dispdrivers/vga2controller.h
+++ b/src/dispdrivers/vga2controller.h
@@ -162,6 +162,9 @@ private:
   void rawDrawBitmap_RGBA8888(int destX, int destY, Bitmap const * bitmap, void * saveBackground, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
+  void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
+
+  // abstract method of BitmappedDisplayController
   void rawFillRow(int y, int x1, int x2, RGB888 color);
   void rawFillRow(int y, int x1, int x2, uint8_t colorIndex);
 

--- a/src/dispdrivers/vga4controller.cpp
+++ b/src/dispdrivers/vga4controller.cpp
@@ -456,6 +456,15 @@ void VGA4Controller::rawDrawBitmap_RGBA8888(int destX, int destY, Bitmap const *
 }
 
 
+void VGA4Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount)
+{
+  genericRawCopyToBitmap(srcX, srcY, width, (uint8_t*)saveBuffer, X1, Y1, XCount, YCount,
+                        [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                        [&] (uint8_t * row, int x) { return VGA4_GETPIXELINROW(row, x); } // rawGetPixelInRow
+                      );
+}
+
+
 void IRAM_ATTR VGA4Controller::ISRHandler(void * arg)
 {
   #if FABGLIB_VGAXCONTROLLER_PERFORMANCE_CHECK

--- a/src/dispdrivers/vga4controller.h
+++ b/src/dispdrivers/vga4controller.h
@@ -159,6 +159,9 @@ private:
   void rawDrawBitmap_RGBA8888(int destX, int destY, Bitmap const * bitmap, void * saveBackground, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
+  void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
+
+  // abstract method of BitmappedDisplayController
   void rawFillRow(int y, int x1, int x2, RGB888 color);
   void rawFillRow(int y, int x1, int x2, uint8_t colorIndex);
 

--- a/src/dispdrivers/vga8controller.cpp
+++ b/src/dispdrivers/vga8controller.cpp
@@ -404,6 +404,15 @@ void VGA8Controller::rawDrawBitmap_RGBA8888(int destX, int destY, Bitmap const *
 }
 
 
+void VGA8Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount)
+{
+  genericRawCopyToBitmap(srcX, srcY, width, (uint8_t*)saveBuffer, X1, Y1, XCount, YCount,
+                        [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                        [&] (uint8_t * row, int x) { return VGA8_GETPIXELINROW(row, x); } // rawGetPixelInRow
+                      );
+}
+
+
 void VGA8Controller::directSetPixel(int x, int y, int value)
 {
   VGA8_SETPIXEL(x, y, value);

--- a/src/dispdrivers/vga8controller.h
+++ b/src/dispdrivers/vga8controller.h
@@ -163,6 +163,9 @@ private:
   void rawDrawBitmap_RGBA8888(int destX, int destY, Bitmap const * bitmap, void * saveBackground, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
+  void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
+
+  // abstract method of BitmappedDisplayController
   void rawFillRow(int y, int x1, int x2, RGB888 color);
   void rawFillRow(int y, int x1, int x2, uint8_t colorIndex);
 

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -559,5 +559,13 @@ void IRAM_ATTR VGAController::rawDrawBitmap_RGBA8888(int destX, int destY, Bitma
 }
 
 
+void IRAM_ATTR VGAController::rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount)
+{
+  genericRawCopyToBitmap(srcX, srcY, width, (uint8_t*)saveBuffer, X1, Y1, XCount, YCount,
+                        [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                        [&] (uint8_t * row, int x) { return VGA_PIXELINROW(row, x); }     // rawGetPixelInRow
+                      );
+}
+
 
 } // end of namespace

--- a/src/dispdrivers/vgacontroller.h
+++ b/src/dispdrivers/vgacontroller.h
@@ -240,6 +240,9 @@ private:
   void rawDrawBitmap_RGBA8888(int destX, int destY, Bitmap const * bitmap, void * saveBackground, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
+  void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
+
+  // abstract method of BitmappedDisplayController
   void rawFillRow(int y, int x1, int x2, RGB888 color);
 
   void rawFillRow(int y, int x1, int x2, uint8_t pattern);

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -774,6 +774,9 @@ void IRAM_ATTR BitmappedDisplayController::execPrimitive(Primitive const & prim,
     case PrimitiveCmd::DrawBitmap:
       drawBitmap(prim.bitmapDrawingInfo, updateRect);
       break;
+    case PrimitiveCmd::CopyToBitmap:
+      copyToBitmap(prim.bitmapDrawingInfo);
+      break;
     case PrimitiveCmd::RefreshSprites:
       hideSprites(updateRect);
       showSprites(updateRect);
@@ -1234,6 +1237,59 @@ void IRAM_ATTR BitmappedDisplayController::absDrawBitmap(int destX, int destY, B
 
 }
 
+
+void IRAM_ATTR BitmappedDisplayController::copyToBitmap(BitmapDrawingInfo const & bitmapCopyingInfo)
+{
+  int x = bitmapCopyingInfo.X + paintState().origin.X;
+  int y = bitmapCopyingInfo.Y + paintState().origin.Y;
+  absCopyToBitmap(x, y, bitmapCopyingInfo.bitmap);
+}
+
+
+void IRAM_ATTR BitmappedDisplayController::absCopyToBitmap(int srcX, int srcY, Bitmap const * bitmap)
+{
+  const int width  = bitmap->width;
+  const int height = bitmap->height;
+  const int clipX1 = 0;
+  const int clipY1 = 0;
+  const int clipX2 = paintState().absClippingRect.X2;
+  const int clipY2 = paintState().absClippingRect.Y2;
+
+  if (srcX > clipX2 || srcY > clipY2)
+    return;
+
+  int X1 = 0;
+  int XCount = width;
+
+  if (srcX < clipX1) {
+    X1 = clipX1 - srcX;
+    srcX = clipX1;
+  }
+  if (X1 >= width)
+    return;
+
+  if (srcX + XCount > clipX2 + 1)
+    XCount = clipX2 + 1 - srcX;
+  if (X1 + XCount > width)
+    XCount = width - X1;
+
+  int Y1 = 0;
+  int YCount = height;
+
+  if (srcY < clipY1) {
+    Y1 = clipY1 - srcY;
+    srcY = clipY1;
+  }
+  if (Y1 >= height)
+    return;
+
+  if (srcY + YCount > clipY2 + 1)
+    YCount = clipY2 + 1 - srcY;
+  if (Y1 + YCount > height)
+    YCount = height - Y1;
+
+  rawCopyToBitmap(srcX, srcY, width, bitmap->data, X1, Y1, XCount, YCount);
+}
 
 
 } // end of namespace


### PR DESCRIPTION
new `Canvas::copyToBitmap(int srcX, int srcY, Bitmap const * bitmap)` function added (plus support code) which copies an area of screen to a pre-supplied `PixelFormat::Native` bitmap object

the bitmap provided must be properly initialised and valid with a suitable buffer.  the width and height of the bitmap, combined with the x and y values provided to the `copyToBitmap` call define the screen area to copy into the bitmap’s buffer

NB in the event that the screen area goes over the edge of the screen then the bitmap buffer area representing the off-screen area will not be touched, so if the bitmap has already been used then it will retain its previous content in those areas