### PR TITLE
dotted line pattern support

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -237,6 +237,42 @@ void Canvas::setLineEnds(LineEnds value)
 }
 
 
+void Canvas::setLinePattern(LinePattern & value)
+{
+  Primitive p;
+  p.cmd = PrimitiveCmd::SetLinePattern;
+  p.linePattern = value;
+  m_displayController->addPrimitive(p);
+}
+
+
+void Canvas::setLinePatternLength(uint8_t value)
+{
+  Primitive p;
+  p.cmd = PrimitiveCmd::SetLinePatternLength;
+  p.ivalue = value;
+  m_displayController->addPrimitive(p);
+}
+
+
+void Canvas::setLinePatternOffset(uint8_t value)
+{
+  Primitive p;
+  p.cmd = PrimitiveCmd::SetLinePatternOffset;
+  p.ivalue = value;
+  m_displayController->addPrimitive(p);
+}
+
+
+void Canvas::setLineOptions(LineOptions options)
+{
+  Primitive p;
+  p.cmd = PrimitiveCmd::SetLineOptions;
+  p.lineOptions = options;
+  m_displayController->addPrimitive(p);
+}
+
+
 void Canvas::setBrushColor(RGB888 const & color)
 {
   Primitive p;

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -318,6 +318,50 @@ public:
   void setLineEnds(LineEnds value);
 
   /**
+   * @brief Sets line pattern
+   * 
+   * @param value Line pattern.
+   * 
+   * Example:
+   * 
+   *    Canvas.setLinePattern(pattern)
+  */
+  void setLinePattern(LinePattern & value);
+
+  /**
+   * @brief Sets line pattern length
+   * 
+   * @param value Line pattern length.
+   * 
+   * Example:
+   * 
+   *   Canvas.setLinePatternLength(length)
+  */
+  void setLinePatternLength(uint8_t value);
+
+  /**
+   * @brief Sets offset position within the line pattern
+   * 
+   * @param value offset position.
+   * 
+   * Example:
+   * 
+   *    Canvas.setLinePatternOffset(position)
+  */
+  void setLinePatternOffset(uint8_t value);
+
+  /**
+   * @brief Sets line drawing options
+   * 
+   * @param value Line drawing options.
+   * 
+   * Example:
+   * 
+   *    Canvas.setLineOptions(LineOptions().Antialias(true).Smooth(true));
+   */
+  void setLineOptions(LineOptions value);
+
+  /**
    * @brief Fills a single pixel with the pen color.
    *
    * @param X Horizontal pixel position.

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -418,6 +418,9 @@ void IRAM_ATTR BitmappedDisplayController::resetPaintState()
   m_paintState.absClippingRect       = m_paintState.clippingRect;
   m_paintState.penWidth              = 1;
   m_paintState.lineEnds              = LineEnds::None;
+  m_paintState.linePattern           = LinePattern();
+  m_paintState.lineOptions           = LineOptions();
+  m_paintState.linePatternLength     = 8;
 }
 
 
@@ -817,6 +820,18 @@ void IRAM_ATTR BitmappedDisplayController::execPrimitive(Primitive const & prim,
       break;
     case PrimitiveCmd::SetLineEnds:
       paintState().lineEnds = prim.lineEnds;
+      break;
+    case PrimitiveCmd::SetLinePattern:
+      paintState().linePattern = prim.linePattern;
+      break;
+    case PrimitiveCmd::SetLinePatternLength:
+      paintState().linePatternLength = imin(64, imax(1, prim.ivalue));
+      break;
+    case PrimitiveCmd::SetLinePatternOffset:
+      paintState().linePattern.offset = prim.ivalue % paintState().linePatternLength;
+      break;
+    case PrimitiveCmd::SetLineOptions:
+      paintState().lineOptions = prim.lineOptions;
       break;
   }
 }

--- a/src/fabutils.cpp
+++ b/src/fabutils.cpp
@@ -373,6 +373,13 @@ Rect IRAM_ATTR Rect::intersection(Rect const & rect) const
 }
 
 
+bool getBit(uint8_t* array, size_t bitIndex) {
+    size_t byteIndex = bitIndex / 8;
+    int bitPosition = 7 - (bitIndex % 8);
+    return (array[byteIndex] >> bitPosition) & 1;
+}
+
+
 ///////////////////////////////////////////////////////////////////////////////////
 // rgb222_to_hsv
 // R, G, B in the 0..3 range

--- a/src/fabutils.h
+++ b/src/fabutils.h
@@ -175,6 +175,9 @@ T moveItems(T dest, T src, size_t n)
 }
 
 
+bool getBit(uint8_t* array, size_t bitIndex);
+
+
 void rgb222_to_hsv(int R, int G, int B, double * h, double * s, double * v);
 
 


### PR DESCRIPTION
Canvas gets several new calls:

`setLinePattern` accepts a LinePattern object for setting a pattern a line can optionally use

`setLinePatternLength` allows the length of the line pattern to be set

`setLinePatternOffset` allows the offset within the pattern to be adjusted

`setLineOptions` sets whether a line should be drawn as a dotted line, and whether its first and/or last points should be omitted

BitmappedDisplayController’s `PaintState` object now includes `linePattern`, `lineOptions` and `linePatternLength`.

`genericAbsDrawLine` now looks at the `lineOptions` in the current paint state to determine whether a dotted line should be drawn, and whether first or last points should be omitted

fabutils gains a `getBit` function which will get a bit at an index within an array of uint8_t numbers.  the position is in “most significant bit” order, i.e. bitIndex 0 is the bit representing 128 in the first byte in the array